### PR TITLE
Rename ShieldtargetAI: v2

### DIFF
--- a/ShieldtargetAI.lua
+++ b/ShieldtargetAI.lua
@@ -1,7 +1,7 @@
 function widget:GetInfo()
 	return {
-		name         = "ShieldtargetAI",
-		desc         = "attempt to make units fire the shields of enemy units. Version 1.00",
+		name         = "ShieldtargetAI v2",
+		desc         = "attempt to make units fire the shields of enemy units. Version 2.00",
 		author       = "terve886",
 		date         = "2019",
 		license      = "PD", -- should be compatible with Spring


### PR DESCRIPTION
This gives the fixed, non-spamming ShieldtargetAI a distinct name.
This means that older versions, which flood `CMD_UNIT_CANCEL_TARGET`,
can be blocked by name. This mechanism could block legitimate versions,
as there will be a set of versions available with the old name that do
not flood, but people with older versions can be simply told to
download the newest version.

See discussion at https://zero-k.info/Battles/Detail/1053004